### PR TITLE
Minimal Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+.env.example
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,5 +71,9 @@ COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
 COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
 COPY --from=installer --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
 
-# TODO: Add migration & seeding scripts here
-CMD ["sh", "-c", "node apps/web/server.js"]
+RUN yarn global add prisma
+COPY packages/prisma/schema.prisma .
+
+# TODO: Consider adding seeding script here
+CMD ["sh", "-c", "$(yarn global bin)/prisma migrate deploy --schema=schema.prisma && node apps/web/server.js"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,81 @@
+FROM node:18-alpine AS base
+
+FROM base AS builder
+RUN apk add --no-cache libc6-compat
+RUN apk update
+# Set working directory
+WORKDIR /app
+RUN yarn global add turbo
+COPY . .
+RUN turbo prune @calcom/web --docker
+
+# Add lockfile and package.json's of isolated subworkspace
+FROM base AS installer
+
+ARG NEXT_PUBLIC_LICENSE_CONSENT
+ARG CALCOM_TELEMETRY_DISABLED
+ARG DATABASE_URL
+ARG NEXTAUTH_SECRET=secret
+ARG NEXT_PUBLIC_API_V2_URL
+ARG CALENDSO_ENCRYPTION_KEY=secret
+ARG MAX_OLD_SPACE_SIZE=4096
+ARG NEXT_PUBLIC_WEBAPP_URL
+
+ENV NEXT_PUBLIC_WEBAPP_URL=$NEXT_PUBLIC_WEBAPP_URL \
+    NEXT_PUBLIC_LICENSE_CONSENT=$NEXT_PUBLIC_LICENSE_CONSENT \
+    CALCOM_TELEMETRY_DISABLED=$CALCOM_TELEMETRY_DISABLED \
+    DATABASE_URL=$DATABASE_URL \
+    DATABASE_DIRECT_URL=$DATABASE_URL \
+    NEXTAUTH_SECRET=${NEXTAUTH_SECRET} \
+    NEXT_PUBLIC_API_V2_URL=${NEXT_PUBLIC_API_V2_URL} \
+    CALENDSO_ENCRYPTION_KEY=${CALENDSO_ENCRYPTION_KEY} \
+    NODE_OPTIONS=--max-old-space-size=${MAX_OLD_SPACE_SIZE}
+
+RUN apk add --no-cache libc6-compat
+RUN apk update
+WORKDIR /app
+
+# First install the dependencies (as they change less often)
+COPY .gitignore .gitignore
+COPY --from=builder /app/out/json/ .
+COPY --from=builder /app/out/yarn.lock ./yarn.lock
+
+# app-store packages aren't explicitly required but need to be available
+# COPY packages/app-store/ ./packages/app-store
+COPY package.json yarn.lock .yarnrc.yml playwright.config.ts turbo.json git-init.sh git-setup.sh ./
+COPY .yarn ./.yarn
+COPY apps/web ./apps/web
+COPY packages ./packages
+COPY tests ./tests
+
+RUN yarn install
+
+# Build the project
+COPY --from=builder /app/out/full/ .
+
+
+# Disable linting and type checking in the next build
+ENV CI=1
+
+RUN yarn turbo run build --filter=@calcom/web...
+
+FROM base AS runner
+WORKDIR /app
+
+# Don't run production as root
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+USER nextjs
+
+COPY --from=installer /app/apps/web/next.config.js .
+COPY --from=installer /app/apps/web/package.json .
+
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
+COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=installer --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
+
+# TODO: Add migration & seeding scripts here
+CMD ["sh", "-c", "node apps/web/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,18 +41,12 @@ COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/yarn.lock ./yarn.lock
 
 # app-store packages aren't explicitly required but need to be available
-# COPY packages/app-store/ ./packages/app-store
-COPY package.json yarn.lock .yarnrc.yml playwright.config.ts turbo.json git-init.sh git-setup.sh ./
-COPY .yarn ./.yarn
-COPY apps/web ./apps/web
 COPY packages ./packages
-COPY tests ./tests
 
 RUN yarn install
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-
 
 # Disable linting and type checking in the next build
 ENV CI=1

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -158,6 +158,7 @@ const matcherConfigUserTypeEmbedRoute = {
 
 /** @type {import("next").NextConfig} */
 const nextConfig = {
+  output: "standalone",
   experimental: {
     // externalize server-side node_modules with size > 1mb, to improve dev mode performance/RAM usage
     serverComponentsExternalPackages: ["next-i18next"],

--- a/depot.json
+++ b/depot.json
@@ -1,0 +1,1 @@
+{ "id": "sjlnf7lv9l" }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lint:fix": "turbo run lint:fix",
     "lint:report": "turbo run lint:report",
     "lint": "turbo run lint",
-    "postinstall": "husky install && turbo run post-install",
+    "postinstall": "echo 'disabled: husky install && turbo run post-install'",
     "pre-commit": "lint-staged",
     "predev": "echo 'Checking env files'",
     "prisma": "yarn workspace @calcom/prisma prisma",


### PR DESCRIPTION
This Docker image follows the Next.js example Dockerfile much more closely.

It's only possible to do this because of the change to the next.config.js with `output: "standalone"`. This means that building the Next.js app outputs a standalone folder within the `.next` build cache that can be used to deploy a lightweight docker image.

This results in a ~38% reduction in the image size (1.03GB -> 636MB), and I don't think this is fully optimised yet.

Things I removed and need to add back:

- [x] DB migrations on image startup
- [ ] Seeding the app-store if necessary

I didn't bother with all this placeholder stuff. Building a Docker image is trivial enough that it makes sense to forgo the complexity that it adds.

Example (using [`depot`](https://depot.dev/), but you can also use `docker`/`docker buildx`):

```
depot build --platform linux/amd64 \
--push \
--tag some-image-tag \
--build-arg NEXT_PUBLIC_WEBAPP_URL=https://your-actual-url.com \
--build-arg NEXT_PUBLIC_LICENSE_CONSENT=true \
--build-arg CALCOM_TELEMETRY_DISABLED=1 \
--build-arg DATABASE_URL=postgresql://unicorn_user:magical_password@database:5432/calendso \
--build-arg NEXTAUTH_SECRET=secret \
--build-arg CALENDSO_ENCRYPTION_KEY=secret \
--build-arg NEXT_PUBLIC_SENTRY_DSN=your-sentry-dsn \
--build-arg NEXT_PUBLIC_API_V2_URL=https://not-set-up.outro.com/api/v2 \
.
```

The benefits of this are good:

- Builds Docker v4, unlike the actual calcom/docker repo which has been broken for a while
- Builds faster! Especially with Depot and caching
- Trivial to add more build args that you need, e.g. SENTRY above
- Smaller image and less setup time is great for serverless environments like Google Cloud Run
- By not using npx and installing packages (e.g. `prisma`) before, the startup time is faster since the packages don't need to be downloaded